### PR TITLE
Fix issue with missing version attribute in data migration instances

### DIFF
--- a/lib/active_record/data_tasks.rb
+++ b/lib/active_record/data_tasks.rb
@@ -78,8 +78,7 @@ module ActiveRecord
           already_done.include?(mig.version)
         end
         data_migrations.each do |migration|
-          require migration.filename
-          (eval(migration.name).new).migrate(:up)
+          migration.migrate(:up)
 
           # push the migration into the database
           ActiveRecord::Base.connection.execute("INSERT INTO data_migrations (version) VALUES (#{migration.version})")


### PR DESCRIPTION
Before this change, the version attribute for the data migration instance was missing, causing [strong_migrations](https://github.com/ankane/strong_migrations) to not work correctly.
